### PR TITLE
Implement livenessprobe for operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN poetry install --no-dev --no-cache
 
 COPY src/* /src/
 
-CMD ["poetry", "run", "kopf", "run", "/src/handlers.py", "--all-namespaces"]
+CMD ["poetry", "run", "kopf", "run", "--liveness=http://0.0.0.0:8080/healthz", "/src/handlers.py", "--all-namespaces"]

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -82,6 +82,12 @@ spec:
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.operator.trivyDojoReportOperator.image.repository }}:{{ .Values.operator.trivyDojoReportOperator.image.tag
           | default .Chart.AppVersion }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 30
         name: trivy-dojo-report-operator
         resources: {}
       serviceAccountName: {{ include "charts.fullname" . }}-account

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -19,7 +19,13 @@ spec:
       serviceAccountName: trivy-dojo-report-account
       containers:
       - name: trivy-dojo-report-operator
-        image: ghcr.io/telekom-mms/docker-trivy-dojo-operator:0.3.1
+        image: ghcr.io/telekom-mms/docker-trivy-dojo-operator:0.3.3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 30
         env:
         - name: DEFECT_DOJO_API_KEY
           valueFrom:

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -8,6 +8,7 @@ environment for this operator.
 - [minikube](https://minikube.sigs.k8s.io/docs/start/)
 - [helm](https://helm.sh/docs/intro/install/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- [poetry](https://python-poetry.org/docs/#installation)
 
 ## Using Minikube
 
@@ -68,7 +69,6 @@ environment for this operator.
 
   ```bash
   kubectl port-forward --namespace=default service/defectdojo-django 8080:80
-  # Access service via http://localhost:8080/
   ```
 
 - [Retrieve DefectDojo API-Key](http://localhost:8080/api/key-v2)


### PR DESCRIPTION
Fixes #22 

Tested by manually changing liveness probe path, Kubernetes restarted the pod

```sh
Events:
  Type     Reason     Age                From               Message
  ----     ------     ----               ----               -------
  Normal   Scheduled  41s                default-scheduler  Successfully assigned default/chart-name-trivy-dojo-report-operator-operator-57c9f5c84-qzjh7 to minikube
  Normal   Pulled     41s                kubelet            Container image "ghcr.io/telekom-mms/docker-trivy-dojo-operator:trivy-dojo-report-operator-0.3.3" already present on machine
  Normal   Created    41s                kubelet            Created container trivy-dojo-report-operator
  Normal   Started    41s                kubelet            Started container trivy-dojo-report-operator
  Warning  Unhealthy  11s (x3 over 31s)  kubelet            Liveness probe failed: Get "http://10.244.0.36:8080/healthzzzzz": dial tcp 10.244.0.36:8080: connect: connection refused
  Normal   Killing    11s                kubelet            Container trivy-dojo-report-operator failed liveness probe, will be restarted
```