### PR TITLE
Refactor chart templating by removing operator as an element

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
   {{- include "charts.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.operator.replicas }}
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       application: trivy-dojo-report-operator
@@ -31,59 +31,59 @@ spec:
               name: {{ include "charts.fullname" . }}-defect-dojo-api-credentials
               optional: false
         - name: DEFECT_DOJO_ACTIVE
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoActive
+          value: {{ quote .Values.env.defectDojoActive
             }}
         - name: DEFECT_DOJO_VERIFIED
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoVerified
+          value: {{ quote .Values.env.defectDojoVerified
             }}
         - name: DEFECT_DOJO_CLOSE_OLD_FINDINGS
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoCloseOldFindings
+          value: {{ quote .Values.env.defectDojoCloseOldFindings
             }}
         - name: DEFECT_DOJO_CLOSE_OLD_FINDINGS_PRODUCT_SCOPE
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoCloseOldFindingsProductScope
+          value: {{ quote .Values.env.defectDojoCloseOldFindingsProductScope
             }}
         - name: DEFECT_DOJO_PUSH_TO_JIRA
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoPushToJira
+          value: {{ quote .Values.env.defectDojoPushToJira
             }}
         - name: DEFECT_DOJO_MINIMUM_SEVERITY
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoMinimumSeverity
+          value: {{ quote .Values.env.defectDojoMinimumSeverity
             }}
         - name: DEFECT_DOJO_AUTO_CREATE_CONTEXT
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoAutoCreateContext
+          value: {{ quote .Values.env.defectDojoAutoCreateContext
             }}
         - name: DEFECT_DOJO_DEDUPLICATION_ON_ENGAGEMENT
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoDeduplicationOnEngagement
+          value: {{ quote .Values.env.defectDojoDeduplicationOnEngagement
             }}
         - name: DEFECT_DOJO_PRODUCT_TYPE_NAME
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoProductTypeName
+          value: {{ quote .Values.env.defectDojoProductTypeName
             }}
         - name: DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalProductTypeName
+          value: {{ quote .Values.env.defectDojoEvalProductTypeName
             }}
         - name: DEFECT_DOJO_TEST_TITLE
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoTestTitle
+          value: {{ quote .Values.env.defectDojoTestTitle
             }}
         - name: DEFECT_DOJO_EVAL_TEST_TITLE
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalTestTitle
+          value: {{ quote .Values.env.defectDojoEvalTestTitle
             }}
         - name: DEFECT_DOJO_ENGAGEMENT_NAME
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEngagementName
+          value: {{ quote .Values.env.defectDojoEngagementName
             }}
         - name: DEFECT_DOJO_EVAL_ENGAGEMENT_NAME
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalEngagementName
+          value: {{ quote .Values.env.defectDojoEvalEngagementName
             }}
         - name: DEFECT_DOJO_PRODUCT_NAME
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoProductName
+          value: {{ quote .Values.env.defectDojoProductName
             }}
         - name: DEFECT_DOJO_EVAL_PRODUCT_NAME
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalProductName
+          value: {{ quote .Values.env.defectDojoEvalProductName
             }}
         - name: DEFECT_DOJO_DO_NOT_REACTIVATE
-          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoDoNotReactivate
+          value: {{ quote .Values.env.defectDojoDoNotReactivate
             }}
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.operator.trivyDojoReportOperator.image.repository }}:{{ .Values.operator.trivyDojoReportOperator.image.tag
+          value: {{ quote .Values.env.kubernetesClusterDomain }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:
@@ -92,7 +92,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 30
         name: trivy-dojo-report-operator
-        {{- if .Values.operator.trivyDojoReportOperator.resources }}
-        resources: {{- toYaml .Values.operator.trivyDojoReportOperator.resources | nindent 10 }}
+        {{- if .Values.resources }}
+        resources: {{- toYaml .Values.resources | nindent 10 }}
         {{- end }}
       serviceAccountName: {{ include "charts.fullname" . }}-account

--- a/charts/templates/rbac.yaml
+++ b/charts/templates/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
   {{- include "charts.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.account.serviceAccount.annotations | nindent 4 }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
   {{- include "charts.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.operator.type }}
+  type: ClusterIP
   selector:
     app.kubernetes.io/instance: trivy-dojo-report-operator
     app.kubernetes.io/name: trivy-dojo-report-operator
   {{- include "charts.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.operator.ports | toYaml | nindent 2 -}}
+	{{- .Values.ports | toYaml | nindent 2 -}}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,38 +1,40 @@
-account:
-  serviceAccount:
-    annotations: {}
 defectDojoApiCredentials:
   apiKey: ""
   url: ""
-kubernetesClusterDomain: cluster.local
-operator:
-  ports:
-    - name: metrics
-      port: 80
-      protocol: TCP
-      targetPort: metrics
-  replicas: 1
-  trivyDojoReportOperator:
-    env:
-      defectDojoActive: "true"
-      defectDojoAutoCreateContext: "true"
-      defectDojoCloseOldFindings: "false"
-      defectDojoCloseOldFindingsProductScope: "false"
-      defectDojoDeduplicationOnEngagement: "true"
-      defectDojoDoNotReactivate: "true"
-      defectDojoEngagementName: engagement
-      defectDojoEvalEngagementName: "false"
-      defectDojoEvalProductName: "false"
-      defectDojoEvalProductTypeName: "false"
-      defectDojoEvalTestTitle: "false"
-      defectDojoMinimumSeverity: Info
-      defectDojoProductName: product
-      defectDojoProductTypeName: Research and Development
-      defectDojoPushToJira: "false"
-      defectDojoTestTitle: Kubernetes
-      defectDojoVerified: "false"
-    image:
-      repository: ghcr.io/telekom-mms/docker-trivy-dojo-operator
-      tag: 0.4.3
-    resources: {}
-  type: ClusterIP
+
+ports:
+  - name: metrics
+    port: 80
+    protocol: TCP
+    targetPort: metrics
+
+replicas: 1
+
+env:
+  kubernetesClusterDomain: cluster.local
+  defectDojoActive: "true"
+  defectDojoAutoCreateContext: "true"
+  defectDojoCloseOldFindings: "false"
+  defectDojoCloseOldFindingsProductScope: "false"
+  defectDojoDeduplicationOnEngagement: "true"
+  defectDojoDoNotReactivate: "true"
+  defectDojoEngagementName: engagement
+  defectDojoEvalEngagementName: "false"
+  defectDojoEvalProductName: "false"
+  defectDojoEvalProductTypeName: "false"
+  defectDojoEvalTestTitle: "false"
+  defectDojoMinimumSeverity: Info
+  defectDojoProductName: product
+  defectDojoProductTypeName: Research and Development
+  defectDojoPushToJira: "false"
+  defectDojoTestTitle: Kubernetes
+  defectDojoVerified: "false"
+
+image:
+  repository: ghcr.io/telekom-mms/docker-trivy-dojo-operator
+  tag: 0.4.3
+
+resources: {}
+
+serviceAccount:
+  annotations: {}

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: trivy-dojo-report-operator
   namespace: mgmt
 spec:
-  clusterIP: None
+  type: ClusterIP
   ports:
     - name: metrics
       port: 80


### PR DESCRIPTION
I removed the layers

```yaml
operator:
  trivyDojoReportOperator:
...
```

to align with other helm charts, and how they are able to configure, e.g. resources like in their values.yaml like

```
resources:
...
```

instead of

```
operator:
  trivyDojoReportOperator
    resources:
...
```

as I think those layers only make sense, if you're able to configure multiple applications within one helm chart
