### PR TITLE
Support multiple reports from trivy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ The trivy-dojo-report-operator is a Kubernetes operator developed using Kopf and
 * Seamless integration with your existing Kubernetes cluster and security workflow.
 * Developed using the Pythonic Kopf framework for easy maintenance and extensibility.
 
+## Supported Reports
+
+* Vulnerability reports
+* RBAC Assessment reports
+* Infra Assessment reports
+* Config Audit reports
+* Exposed secrets
+
 ## Prerequisites
 
 * A running Kubernetes cluster (minikube, kind, or another environment)
@@ -82,30 +90,37 @@ You can also run the operator locally. This way you don't have to install anythi
 ```bash
 docker pull ghcr.io/telekom-mms/docker-trivy-dojo-operator
 
-docker run -it -v /path/to/your/.kube/config:/root/.kube/config -e DEFECT_DOJO_API_KEY=$DEFECT_DOJO_API_KEY -e DEFECT_DOJO_URL=$DEFECT_DOJO_URL -e LABEL="trivy-operator.resource.name" -e LABEL_VALUE="master-live-server" ghcr.io/telekom-mms/docker-trivy-dojo-operator
+docker run -it -v /path/to/your/.kube/config:/root/.kube/config \
+  -e DEFECT_DOJO_API_KEY=$DEFECT_DOJO_API_KEY \
+  -e DEFECT_DOJO_URL=$DEFECT_DOJO_URL \
+  -e LABEL="trivy-operator.resource.name" \
+  -e LABEL_VALUE="master-live-server" \
+  -e REPORTS="vulnerabilityreports"
+  ghcr.io/telekom-mms/docker-trivy-dojo-operator
 ```
 
 ## Configuration
 
-| Variable                             | Default Value          | Description                                                                                  |
-|--------------------------------------|------------------------|----------------------------------------------------------------------------------------------|
-| `defectDojoActive`                    | `"true"`               | Override the active setting from the tool.                                                  |
-| `defectDojoAutoCreateContext`         | `"true"`               | Specifies whether to automatically create Engagements, Products and Product_Types           |
-| `defectDojoCloseOldFindings`          | `"false"`              | Select if old findings no longer present in the report get closed as mitigated when importing. If service has been set, only the findings for this service will be closed. |
-| `defectDojoCloseOldFindingsProductScope` | `"false"`           | Select if close_old_findings applies to all findings of the same type in the product. By default, it is false meaning that only old findings of the same type in the engagement are in scope. |
-| `defectDojoDeduplicationOnEngagement` | `"true"`               | restrict deduplication for imported Findings to the newly created Engagement.               |
-| `defectDojoEngagementName`            | `engagement`           | The name of the engagement in DefectDojo.                                                   |
-| `defectDojoEvalEngagementName`        | `"false"`              | Specifies whether the engagement name should be evaluated as a python function.             |
-| `defectDojoEvalProductName`           | `"false"`              | Specifies whether the product name should be evaluated as a python function.                |
-| `defectDojoEvalProductTypeName`       | `"false"`              | Specifies whether the product type name should be evaluated as a python function.           |
-| `defectDojoEvalTestTitle`             | `"false"`              | Specifies whether the test title should be evaluated as a python function.                  |
-| `defectDojoMinimumSeverity`           | `Info`                 | The minimum severity level for findings in DefectDojo.                                      |
-| `defectDojoProductName`               | `product`              | The name of the product in DefectDojo.                                                      |
-| `defectDojoProductTypeName`           | `Research and Development` | The type of the product in DefectDojo.                                                  |
-| `defectDojoPushToJira`                | `"false"`              | Specifies whether findings should be pushed to Jira in DefectDojo.                          |
-| `defectDojoTestTitle`                 | `Kubernetes`           | The title of the test in DefectDojo.                                                        |
-| `defectDojoVerified`                  | `"false"`              | Specifies whether findings should be marked as verified in DefectDojo.                      |
-| `defectDojoDoNotReactivate`           | `"true"`               | If true the importing/reimporting will ignore uploaded active findings and not reactivate previously closed findings, while still creating new findings if there are new ones                |
+| Variable                             | Default Value               | Description                                                                                  |
+|--------------------------------------|-----------------------------|----------------------------------------------------------------------------------------------|
+| `defectDojoActive`                    | `"true"`                   | Override the active setting from the tool.                                                   |
+| `defectDojoAutoCreateContext`         | `"true"`                   | Specifies whether to automatically create Engagements, Products and Product_Types            |
+| `defectDojoCloseOldFindings`          | `"false"`                  | Select if old findings no longer present in the report get closed as mitigated when importing. If service has been set, only the findings for this service will be closed. |
+| `defectDojoCloseOldFindingsProductScope` | `"false"`               | Select if close_old_findings applies to all findings of the same type in the product. By default, it is false meaning that only old findings of the same type in the engagement are in scope. |
+| `defectDojoDeduplicationOnEngagement` | `"true"`                   | restrict deduplication for imported Findings to the newly created Engagement.                |
+| `defectDojoEngagementName`            | `engagement`               | The name of the engagement in DefectDojo.                                                    |
+| `defectDojoEvalEngagementName`        | `"false"`                  | Specifies whether the engagement name should be evaluated as a python function.              |
+| `defectDojoEvalProductName`           | `"false"`                  | Specifies whether the product name should be evaluated as a python function.                 |
+| `defectDojoEvalProductTypeName`       | `"false"`                  | Specifies whether the product type name should be evaluated as a python function.            |
+| `defectDojoEvalTestTitle`             | `"false"`                  | Specifies whether the test title should be evaluated as a python function.                   |
+| `defectDojoMinimumSeverity`           | `Info`                     | The minimum severity level for findings in DefectDojo.                                       |
+| `defectDojoProductName`               | `product`                  | The name of the product in DefectDojo.                                                       |
+| `defectDojoProductTypeName`           | `Research and Development` | The type of the product in DefectDojo.                                                       |
+| `defectDojoPushToJira`                | `"false"`                  | Specifies whether findings should be pushed to Jira in DefectDojo.                           |
+| `defectDojoTestTitle`                 | `Kubernetes`               | The title of the test in DefectDojo.                                                         |
+| `defectDojoVerified`                  | `"false"`                  | Specifies whether findings should be marked as verified in DefectDojo.                       |
+| `defectDojoDoNotReactivate`           | `"true"`                   | If true the importing/reimporting will ignore uploaded active findings and not reactivate previously closed findings, while still creating new findings if there are new ones             |
+| `reports`                             | `"vulnerabilityreports"`   | Comma-separated list of reports that should be sent to DefectDojo. Possibilities: vulnerabilityreports, rbacassessmentreports, infraassessmentreports, configauditreports, exposedsecrets |
 
 ### A note on eval
 

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
         - name: DEFECT_DOJO_DO_NOT_REACTIVATE
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoDoNotReactivate
             }}
+        - name: REPORTS
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.reports }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.operator.trivyDojoReportOperator.image.repository }}:{{ .Values.operator.trivyDojoReportOperator.image.tag
@@ -92,7 +94,5 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 30
         name: trivy-dojo-report-operator
-        {{- if .Values.operator.trivyDojoReportOperator.resources }}
-        resources: {{- toYaml .Values.operator.trivyDojoReportOperator.resources | nindent 10 }}
-        {{- end }}
+        resources: {}
       serviceAccountName: {{ include "charts.fullname" . }}-account

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -7,10 +7,10 @@ defectDojoApiCredentials:
 kubernetesClusterDomain: cluster.local
 operator:
   ports:
-    - name: metrics
-      port: 80
-      protocol: TCP
-      targetPort: metrics
+  - name: metrics
+    port: 80
+    protocol: TCP
+    targetPort: metrics
   replicas: 1
   trivyDojoReportOperator:
     env:
@@ -31,8 +31,8 @@ operator:
       defectDojoPushToJira: "false"
       defectDojoTestTitle: Kubernetes
       defectDojoVerified: "false"
+      reports: vulnerabilityreports
     image:
       repository: ghcr.io/telekom-mms/docker-trivy-dojo-operator
       tag: 0.4.3
-    resources: {}
   type: ClusterIP

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -74,3 +74,5 @@ spec:
               value: "false"
             - name: DEFECT_DOJO_DO_NOT_REACTIVATE
               value: "true"
+            - name: REPORTS
+              value: "vulnerabilityreports"

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -17,6 +17,22 @@ PROMETHEUS_DISABLE_CREATED_SERIES = True
 c = prometheus.Counter("requests_total", "HTTP Requests", ["status"])
 
 
+def check_allowed_reports(report: str):
+    allowed_reports: list[str] = [
+        "configauditreports",
+        "vulnerabilityreports",
+        "exposedsecretreports",
+        "infraassessmentreports",
+        "rbacassessmentreports",
+    ]
+
+    if report not in allowed_reports:
+        print(
+            f"[ERROR] report {report} is not allowed. Allowed reports: {allowed_reports}"
+        )
+        exit(1)
+
+
 @kopf.on.startup()
 def configure(settings: kopf.OperatorSettings, **_):
     """
@@ -49,101 +65,104 @@ if settings.LABEL and settings.LABEL_VALUE:
 else:
     labels = {}
 
+for report in settings.REPORTS:
+    # check if reports are allowed
+    check_allowed_reports(report)
 
-@kopf.on.create("vulnerabilityreports.aquasecurity.github.io", labels=labels)
-@REQUEST_TIME.time()
-def send_to_dojo(body, meta, logger, **_):
-    """
-    The main function that creates a report-file from the trivy-operator vulnerabilityreport
-    and sends it to the defectdojo instance.
-    """
+    @REQUEST_TIME.time()
+    @kopf.on.create(report.lower() + ".aquasecurity.github.io", labels=labels)
+    def send_to_dojo(body, meta, logger, **_):
+        """
+        The main function that creates a report-file from the trivy-operator vulnerabilityreport
+        and sends it to the defectdojo instance.
+        """
 
-    logger.info(f"Working on {meta['name']}")
+        logger.info(f"Working on {body['kind']} {meta['name']}")
 
-    # body is the whole kubernetes manifest of a vulnerabilityreport
-    # body is a Python-Object that is not json-serializable,
-    # but body[kind], body[metadata] and so on are
-    # so we create a new json-object here, since kopf does not provide this
-    full_object: dict = {}
-    for i in body:
-        full_object[i] = body[i]
+        # body is the whole kubernetes manifest of a vulnerabilityreport
+        # body is a Python-Object that is not json-serializable,
+        # but body[kind], body[metadata] and so on are
+        # so we create a new json-object here, since kopf does not provide this
+        full_object: dict = {}
+        for i in body:
+            full_object[i] = body[i]
 
-    logger.debug(full_object)
+        logger.debug(full_object)
 
-    _DEFECT_DOJO_ENGAGEMENT_NAME = (
-        eval(settings.DEFECT_DOJO_ENGAGEMENT_NAME)
-        if settings.DEFECT_DOJO_EVAL_ENGAGEMENT_NAME
-        else settings.DEFECT_DOJO_ENGAGEMENT_NAME
-    )
-
-    _DEFECT_DOJO_PRODUCT_NAME = (
-        eval(settings.DEFECT_DOJO_PRODUCT_NAME)
-        if settings.DEFECT_DOJO_EVAL_PRODUCT_NAME
-        else settings.DEFECT_DOJO_PRODUCT_NAME
-    )
-
-    _DEFECT_DOJO_PRODUCT_TYPE_NAME = (
-        eval(settings.DEFECT_DOJO_PRODUCT_TYPE_NAME)
-        if settings.DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME
-        else settings.DEFECT_DOJO_PRODUCT_TYPE_NAME
-    )
-
-    _DEFECT_DOJO_TEST_TITLE = (
-        eval(settings.DEFECT_DOJO_TEST_TITLE)
-        if settings.DEFECT_DOJO_EVAL_TEST_TITLE
-        else settings.DEFECT_DOJO_TEST_TITLE
-    )
-
-    # define the vulnerabilityreport as a json-file so DD accepts it
-    json_string: str = json.dumps(full_object)
-    json_file: BytesIO = BytesIO(json_string.encode("utf-8"))
-    report_file: dict = {"file": ("report.json", json_file)}
-
-    headers: dict = {
-        "Authorization": "Token " + settings.DEFECT_DOJO_API_KEY,
-        "Accept": "application/json",
-    }
-
-    data: dict = {
-        "active": settings.DEFECT_DOJO_ACTIVE,
-        "verified": settings.DEFECT_DOJO_VERIFIED,
-        "close_old_findings": settings.DEFECT_DOJO_CLOSE_OLD_FINDINGS,
-        "close_old_findings_product_scope": settings.DEFECT_DOJO_CLOSE_OLD_FINDINGS_PRODUCT_SCOPE,
-        "push_to_jira": settings.DEFECT_DOJO_PUSH_TO_JIRA,
-        "minimum_severity": settings.DEFECT_DOJO_MINIMUM_SEVERITY,
-        "auto_create_context": settings.DEFECT_DOJO_AUTO_CREATE_CONTEXT,
-        "deduplication_on_engagement": settings.DEFECT_DOJO_DEDUPLICATION_ON_ENGAGEMENT,
-        "scan_type": "Trivy Operator Scan",
-        "engagement_name": _DEFECT_DOJO_ENGAGEMENT_NAME,
-        "product_name": _DEFECT_DOJO_PRODUCT_NAME,
-        "product_type_name": _DEFECT_DOJO_PRODUCT_TYPE_NAME,
-        "test_title": _DEFECT_DOJO_TEST_TITLE,
-        "do_not_reactivate": settings.DEFECT_DOJO_DO_NOT_REACTIVATE,
-    }
-
-    logger.debug(data)
-
-    try:
-        response: requests.Response = requests.post(
-            settings.DEFECT_DOJO_URL + "/api/v2/reimport-scan/",
-            headers=headers,
-            data=data,
-            files=report_file,
-            verify=True,
+        _DEFECT_DOJO_ENGAGEMENT_NAME = (
+            eval(settings.DEFECT_DOJO_ENGAGEMENT_NAME)
+            if settings.DEFECT_DOJO_EVAL_ENGAGEMENT_NAME
+            else settings.DEFECT_DOJO_ENGAGEMENT_NAME
         )
-        response.raise_for_status()
-    except HTTPError as http_err:
-        c.labels("failed").inc()
-        raise kopf.TemporaryError(
-            f"HTTP error occurred: {http_err} - {response.content}. Retrying in 60 seconds",
-            delay=60,
+
+        _DEFECT_DOJO_PRODUCT_NAME = (
+            eval(settings.DEFECT_DOJO_PRODUCT_NAME)
+            if settings.DEFECT_DOJO_EVAL_PRODUCT_NAME
+            else settings.DEFECT_DOJO_PRODUCT_NAME
         )
-    except Exception as err:
-        c.labels("failed").inc()
-        raise kopf.TemporaryError(
-            f"Other error occurred: {err}. Retrying in 60 seconds", delay=60
+
+        _DEFECT_DOJO_PRODUCT_TYPE_NAME = (
+            eval(settings.DEFECT_DOJO_PRODUCT_TYPE_NAME)
+            if settings.DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME
+            else settings.DEFECT_DOJO_PRODUCT_TYPE_NAME
         )
-    else:
-        c.labels("success").inc()
-        logger.info(f"Finished {meta['name']}")
-        logger.debug(response.content)
+
+        _DEFECT_DOJO_TEST_TITLE = (
+            eval(settings.DEFECT_DOJO_TEST_TITLE)
+            if settings.DEFECT_DOJO_EVAL_TEST_TITLE
+            else settings.DEFECT_DOJO_TEST_TITLE
+        )
+
+        # define the vulnerabilityreport as a json-file so DD accepts it
+        json_string: str = json.dumps(full_object)
+        json_file: BytesIO = BytesIO(json_string.encode("utf-8"))
+        report_file: dict = {"file": ("report.json", json_file)}
+
+        headers: dict = {
+            "Authorization": "Token " + settings.DEFECT_DOJO_API_KEY,
+            "Accept": "application/json",
+        }
+
+        data: dict = {
+            "active": settings.DEFECT_DOJO_ACTIVE,
+            "verified": settings.DEFECT_DOJO_VERIFIED,
+            "close_old_findings": settings.DEFECT_DOJO_CLOSE_OLD_FINDINGS,
+            "close_old_findings_product_scope": settings.DEFECT_DOJO_CLOSE_OLD_FINDINGS_PRODUCT_SCOPE,
+            "push_to_jira": settings.DEFECT_DOJO_PUSH_TO_JIRA,
+            "minimum_severity": settings.DEFECT_DOJO_MINIMUM_SEVERITY,
+            "auto_create_context": settings.DEFECT_DOJO_AUTO_CREATE_CONTEXT,
+            "deduplication_on_engagement": settings.DEFECT_DOJO_DEDUPLICATION_ON_ENGAGEMENT,
+            "scan_type": "Trivy Operator Scan",
+            "engagement_name": _DEFECT_DOJO_ENGAGEMENT_NAME,
+            "product_name": _DEFECT_DOJO_PRODUCT_NAME,
+            "product_type_name": _DEFECT_DOJO_PRODUCT_TYPE_NAME,
+            "test_title": _DEFECT_DOJO_TEST_TITLE,
+            "do_not_reactivate": settings.DEFECT_DOJO_DO_NOT_REACTIVATE,
+        }
+
+        logger.debug(data)
+
+        try:
+            response: requests.Response = requests.post(
+                settings.DEFECT_DOJO_URL + "/api/v2/reimport-scan/",
+                headers=headers,
+                data=data,
+                files=report_file,
+                verify=True,
+            )
+            response.raise_for_status()
+        except HTTPError as http_err:
+            c.labels("failed").inc()
+            raise kopf.TemporaryError(
+                f"HTTP error occurred: {http_err} - {response.content}. Retrying in 60 seconds",
+                delay=60,
+            )
+        except Exception as err:
+            c.labels("failed").inc()
+            raise kopf.TemporaryError(
+                f"Other error occurred: {err}. Retrying in 60 seconds", delay=60
+            )
+        else:
+            c.labels("success").inc()
+            logger.info(f"Finished {body['kind']} {meta['name']}")
+            logger.debug(response.content)

--- a/src/settings.py
+++ b/src/settings.py
@@ -56,3 +56,7 @@ DEFECT_DOJO_PRODUCT_NAME: str = os.getenv(
 DEFECT_DOJO_EVAL_PRODUCT_NAME: bool = get_env_var_bool("DEFECT_DOJO_EVAL_PRODUCT_NAME")
 
 DEFECT_DOJO_DO_NOT_REACTIVATE: bool = get_env_var_bool("DEFECT_DOJO_DO_NOT_REACTIVATE")
+
+LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
+
+REPORTS: list = os.getenv("REPORTS", "vulnerabilityreports").split(",")


### PR DESCRIPTION
This change allows the user to configure which reports the operator will send to DefectDojo. By default only Vulnerability Reports will be sent.