### PR TITLE
Update service.yaml

### DIFF
--- a/charts/templates/service.yaml
+++ b/charts/templates/service.yaml
@@ -7,8 +7,6 @@ metadata:
 spec:
   type: {{ .Values.operator.type }}
   selector:
-    app.kubernetes.io/instance: trivy-dojo-report-operator
-    app.kubernetes.io/name: trivy-dojo-report-operator
   {{- include "charts.selectorLabels" . | nindent 4 }}
   ports:
 	{{- .Values.operator.ports | toYaml | nindent 2 -}}


### PR DESCRIPTION
Hello!

The fields in the selector within the services are getting duplicated when generated, and this is causing issues in FluxCD v2.

I'm implementing your chart in my FluxCD setup. However, while conducting tests, I encountered the mentioned error. I noticed a related issue on https://github.com/fluxcd/helm-controller/issues/283. I tried the suggested test at the end of the thread using a shell script to generate the Helm template, and that's when I observed the issue of duplicated selectors.

Error:

Helm install failed for release trivy-report-operator/trivy-dojo-operator with chart trivy-dojo-report-operator@0.6.1: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 20: mapping key "app.kubernetes.io/instance" already defined at line 17 line 19: mapping key "app.kubernetes.io/name" already defined at line 18