### PR TITLE
Allow disabling of SSL certificate verification; Adds Git Ref description to engagement test

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,14 @@ For a local development setup, please take a look at
 | `defectDojoEvalProductTypeName`       | `"false"`                  | Specifies whether the product type name should be evaluated as a python function.            |
 | `defectDojoEvalServiceName`           | `"false"`                  | Specifies whether the service name should be evaluated as a python function.                 |
 | `defectDojoEvalEnvName`               | `"false"`                  | Specifies whether the enviroment type name should be evaluated as a python function.         |
+| `defectDojoEvalGitRef   `             | `"false"`                  | Specifies whether the Git Ref should be evaluated as a python function.         |
 | `defectDojoEvalTestTitle`             | `"false"`                  | Specifies whether the test title should be evaluated as a python function.                   |
 | `defectDojoMinimumSeverity`           | `Info`                     | The minimum severity level for findings in DefectDojo.                                       |
 | `defectDojoProductName`               | `product`                  | The name of the product in DefectDojo.                                                       |
 | `defectDojoProductTypeName`           | `Research and Development` | The type of the product in DefectDojo.                                                       |
 | `defectDojoServiceName`               | ``                         | The name of the service in DefectDojo.                                                       |
 | `defectDojoEnvName`                   | `Development`              | The type of the env in DefectDojo.                                                           |
+| `defectDojoGitRef`                    | `development`               | The name of the Git Ref to be specified in DefectDojo (e.g.: `main`, `development`, etc.).                                                             |
 | `defectDojoPushToJira`                | `"false"`                  | Specifies whether findings should be pushed to Jira in DefectDojo.                           |
 | `defectDojoTestTitle`                 | `Kubernetes`               | The title of the test in DefectDojo.                                                         |
 | `defectDojoVerified`                  | `"false"`                  | Specifies whether findings should be marked as verified in DefectDojo.                       |
@@ -134,6 +136,10 @@ evaluated and used as the engagement name.
 
 If you set defectDojoEngagementName to `body["report"]["artifact"]["tag"]`,
 then the engagement will get the name of the specified image-tag.
+
+### A note on DefectDojo Credentials
+
+In case your installation of DefectDojo doesn't has a verifiable SSL certificate (e.g. it is only accessible in a very well controlled environment), you are able to disable the verification of the SSL certificate by assigning the verifySSL flag as false on the Helm Chart `values.yaml` configuration.
 
 ## Metrics
 

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -30,6 +30,12 @@ spec:
               key: url
               name: {{ include "charts.fullname" . }}-defect-dojo-api-credentials
               optional: false
+        - name: DEFECT_DOJO_VERIFY_SSL
+          valueFrom:
+            secretKeyRef:
+              key: verifySSL
+              name: {{ include "charts.fullname" . }}-defect-dojo-api-credentials
+              optional: true
         - name: DEFECT_DOJO_ACTIVE
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoActive
             }}
@@ -77,6 +83,12 @@ spec:
             }}
         - name: DEFECT_DOJO_EVAL_ENGAGEMENT_NAME
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalEngagementName
+            }}
+        - name: DEFECT_DOJO_GIT_REF
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoGitRef
+            }}
+        - name: DEFECT_DOJO_EVAL_GIT_REF
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalGitRef
             }}
         - name: DEFECT_DOJO_PRODUCT_NAME
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoProductName

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -10,5 +10,10 @@ stringData:
     | quote }}
   url: {{ required "defectDojoApiCredentials.url is required" .Values.defectDojoApiCredentials.url
     | quote }}
+  verifySSL: {{ if .Values.defectDojoApiCredentials.verifySSL }}
+      {{ .Values.defectDojoApiCredentials.verifySSL | quote }}
+    {{ else }}
+      "true"
+    {{ end }}
 type: Opaque
 {{ end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -2,6 +2,7 @@ defectDojoApiCredentials:
   createSecret: true
   apiKey: "YOUR_DEFECTDOJO_API_KEY"
   url: "YOUR_DEFECTDOJO_URL"
+  verifySSL: "true"
 kubernetesClusterDomain: cluster.local
 account:
   serviceAccount:
@@ -42,9 +43,11 @@ operator:
       defectDojoEnvName: Development
       defectDojoEvalEngagementName: "false"
       defectDojoEvalEnvName: "false"
+      defectDojoEvalGitRef: "false"
       defectDojoEvalProductName: "false"
       defectDojoEvalProductTypeName: "false"
       defectDojoEvalTestTitle: "false"
+      defectDojoGitRef: "development"
       defectDojoMinimumSeverity: Info
       defectDojoProductName: product
       defectDojoProductTypeName: Research and Development

--- a/deploy/trivy-dojo-report-operator.yaml
+++ b/deploy/trivy-dojo-report-operator.yaml
@@ -27,6 +27,7 @@ metadata:
 stringData:
   apiKey: "YOUR_DEFECTDOJO_API_KEY"
   url: "YOUR_DEFECTDOJO_URL"
+  verifySSL: "true"
 type: Opaque
 ---
 # Source: trivy-dojo-report-operator/templates/rbac.yaml
@@ -156,6 +157,12 @@ spec:
               key: url
               name: telekom-mms-trivy-dojo-report-operator-defect-dojo-api-credentials
               optional: false
+        - name: DEFECT_DOJO_VERIFY_SSL
+          valueFrom:
+            secretKeyRef:
+              key: verifySSL
+              name: telekom-mms-trivy-dojo-report-operator-defect-dojo-api-credentials
+              optional: true
         - name: DEFECT_DOJO_ACTIVE
           value: "true"
         - name: DEFECT_DOJO_VERIFIED
@@ -198,6 +205,10 @@ spec:
           value: 
         - name: DEFECT_DOJO_DO_NOT_REACTIVATE
           value: "true"
+        - name: DEFECT_DOJO_GIT_REF
+          value: "development"
+        - name: DEFECT_DOJO_EVAL_GIT_REF
+          value: "false"
         - name: REPORTS
           value: "vulnerabilityreports"
         - name: KUBERNETES_CLUSTER_DOMAIN

--- a/src/env_vars.py
+++ b/src/env_vars.py
@@ -13,6 +13,11 @@ def get_required_env_var(name):
         exit(1)
 
 
-def get_env_var_bool(name):
-    """Gets value of environment variable as a boolean. If not 'true', returns False"""
-    return os.getenv(name) == "true"
+def get_env_var_bool(name, default_value:bool=False):
+    """Gets value of environment variable as a boolean. If not 'true', returns False.
+        In case the environment variable does not exist, returns a default value of False or True if specified."""
+
+    if os.getenv(name) is not None:
+        return os.getenv(name) == "true"
+    else:
+        return default_value

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -128,6 +128,12 @@ for report in settings.REPORTS:
             else settings.DEFECT_DOJO_TEST_TITLE
         )
 
+        _DEFECT_DOJO_GIT_REF = (
+            eval(settings.DEFECT_DOJO_GIT_REF)
+            if settings.DEFECT_DOJO_EVAL_GIT_REF
+            else settings.DEFECT_DOJO_GIT_REF
+        )
+
         # define the vulnerabilityreport as a json-file so DD accepts it
         json_string: str = json.dumps(full_object)
         json_file: BytesIO = BytesIO(json_string.encode("utf-8"))
@@ -151,6 +157,7 @@ for report in settings.REPORTS:
             "engagement_name": _DEFECT_DOJO_ENGAGEMENT_NAME,
             "product_name": _DEFECT_DOJO_PRODUCT_NAME,
             "product_type_name": _DEFECT_DOJO_PRODUCT_TYPE_NAME,
+            "branch_tag": _DEFECT_DOJO_GIT_REF,
             "service": _DEFECT_DOJO_SERVICE_NAME,
             "environment": _DEFECT_DOJO_ENV_NAME,
             "test_title": _DEFECT_DOJO_TEST_TITLE,
@@ -165,7 +172,7 @@ for report in settings.REPORTS:
                 headers=headers,
                 data=data,
                 files=report_file,
-                verify=True,
+                verify=settings.DEFECT_DOJO_VERIFY_SSL,
                 proxies=proxies,
             )
             response.raise_for_status()

--- a/src/settings.py
+++ b/src/settings.py
@@ -17,6 +17,7 @@ else:
 
 DEFECT_DOJO_API_KEY: str = get_required_env_var("DEFECT_DOJO_API_KEY")
 DEFECT_DOJO_URL: str = get_required_env_var("DEFECT_DOJO_URL")
+DEFECT_DOJO_VERIFY_SSL: bool = get_env_var_bool("DEFECT_DOJO_VERIFY_SSL", True)
 
 DEFECT_DOJO_ACTIVE: bool = get_env_var_bool("DEFECT_DOJO_ACTIVE")
 DEFECT_DOJO_VERIFIED: bool = get_env_var_bool("DEFECT_DOJO_VERIFIED")
@@ -62,6 +63,11 @@ DEFECT_DOJO_EVAL_TEST_TITLE: bool = get_env_var_bool("DEFECT_DOJO_EVAL_TEST_TITL
 DEFECT_DOJO_ENGAGEMENT_NAME: str | None = os.getenv("DEFECT_DOJO_ENGAGEMENT_NAME")
 DEFECT_DOJO_EVAL_ENGAGEMENT_NAME: bool = get_env_var_bool(
     "DEFECT_DOJO_EVAL_ENGAGEMENT_NAME"
+)
+
+DEFECT_DOJO_GIT_REF: str | None = os.getenv("DEFECT_DOJO_GIT_REF")
+DEFECT_DOJO_EVAL_GIT_REF: bool = get_env_var_bool(
+    "DEFECT_DOJO_EVAL_GIT_REF"
 )
 
 DEFECT_DOJO_PRODUCT_NAME: str = os.getenv(


### PR DESCRIPTION
**Identified Problems**
1. The `send_to_dojo` method that publishes findings to an engagement on Defect Dojo fails on networks where Defect Dojo doesn't have a verifiable SSL certificate. 
2. It's difficult to identify the version of the resource where the finding is present at.

**Proposed Solutions**
1. Add a field in the configuration to disable the SSL verification on the `send_to_dojo` method. If nothing is specified the validation should be enabled.
2. Add a field in the configuration similar to the *Product Name*/*Engagement Name* ones, that will allow the definition of the Branch/Tag field in the Defect Dojo Engagement Test.