### PR TITLE
feat: add support for setting 'Service'

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,13 @@ docker run -it -v /path/to/your/.kube/config:/root/.kube/config \
 | `defectDojoEvalEngagementName`        | `"false"`                  | Specifies whether the engagement name should be evaluated as a python function.              |
 | `defectDojoEvalProductName`           | `"false"`                  | Specifies whether the product name should be evaluated as a python function.                 |
 | `defectDojoEvalProductTypeName`       | `"false"`                  | Specifies whether the product type name should be evaluated as a python function.            |
+| `defectDojoEvalServiceName`           | `"false"`                  | Specifies whether the service name should be evaluated as a python function.                 |
 | `defectDojoEvalEnvName`               | `"false"`                  | Specifies whether the enviroment type name should be evaluated as a python function.         |
 | `defectDojoEvalTestTitle`             | `"false"`                  | Specifies whether the test title should be evaluated as a python function.                   |
 | `defectDojoMinimumSeverity`           | `Info`                     | The minimum severity level for findings in DefectDojo.                                       |
 | `defectDojoProductName`               | `product`                  | The name of the product in DefectDojo.                                                       |
 | `defectDojoProductTypeName`           | `Research and Development` | The type of the product in DefectDojo.                                                       |
+| `defectDojoServiceName`               | ``                         | The name of the service in DefectDojo.                                                       |
 | `defectDojoEnvName`                   | `Development`              | The type of the env in DefectDojo.                                                           |
 | `defectDojoPushToJira`                | `"false"`                  | Specifies whether findings should be pushed to Jira in DefectDojo.                           |
 | `defectDojoTestTitle`                 | `Kubernetes`               | The title of the test in DefectDojo.                                                         |

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -84,6 +84,12 @@ spec:
         - name: DEFECT_DOJO_EVAL_PRODUCT_NAME
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalProductName
             }}
+        - name: DEFECT_DOJO_SERVICE_NAME
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoServiceName
+            }}
+        - name: DEFECT_DOJO_EVAL_SERVICE_NAME
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoEvalServiceName
+            }}
         - name: DEFECT_DOJO_DO_NOT_REACTIVATE
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoDoNotReactivate
             }}

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -106,6 +106,11 @@ for report in settings.REPORTS:
             if settings.DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME
             else settings.DEFECT_DOJO_PRODUCT_TYPE_NAME
         )
+        _DEFECT_DOJO_SERVICE_NAME = (
+            eval(settings.DEFECT_DOJO_SERVICE_NAME)
+            if settings.DEFECT_DOJO_EVAL_SERVICE_NAME
+            else settings.DEFECT_DOJO_SERVICE_NAME
+        )
 
         _DEFECT_DOJO_ENV_NAME = (
             eval(settings.DEFECT_DOJO_ENV_NAME)
@@ -142,6 +147,7 @@ for report in settings.REPORTS:
             "engagement_name": _DEFECT_DOJO_ENGAGEMENT_NAME,
             "product_name": _DEFECT_DOJO_PRODUCT_NAME,
             "product_type_name": _DEFECT_DOJO_PRODUCT_TYPE_NAME,
+            "service": _DEFECT_DOJO_SERVICE_NAME,
             "environment": _DEFECT_DOJO_ENV_NAME,
             "test_title": _DEFECT_DOJO_TEST_TITLE,
             "do_not_reactivate": settings.DEFECT_DOJO_DO_NOT_REACTIVATE,

--- a/src/settings.py
+++ b/src/settings.py
@@ -42,6 +42,13 @@ DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME: bool = get_env_var_bool(
     "DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME"
 )
 
+DEFECT_DOJO_SERVICE_NAME: str = os.getenv(
+    "DEFECT_DOJO_SERVICE_NAME", ""
+)
+DEFECT_DOJO_EVAL_SERVICE_NAME: bool = get_env_var_bool(
+    "DEFECT_DOJO_EVAL_SERVICE_TYPE_NAME"
+)
+
 DEFECT_DOJO_ENV_NAME: str = os.getenv(
     "DEFECT_DOJO_ENV_NAME", "Development"
 )


### PR DESCRIPTION
One of our products runs many many copies in different deployments. Without being able to set Service, we end up with significant duplicate findings, each only different by:

- dex/ReplicaSet/dex-79fd8bbc9b/dex
- dex/ReplicaSet/dex-994dcadd1a/dex ...