### PR TITLE
Allow variable DEFECT_DOJO_PRODUCT_TYPE_NAME empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ docker pull ghcr.io/telekom-mms/docker-trivy-dojo-operator
 docker run -it -v /path/to/your/.kube/config:/root/.kube/config \
   -e DEFECT_DOJO_API_KEY=$DEFECT_DOJO_API_KEY \
   -e DEFECT_DOJO_URL=$DEFECT_DOJO_URL \
+  -e DEFECT_DOJO_PRODUCT_TYPE_NAME="Research and Development" \
   -e LABEL="trivy-operator.resource.name" \
   -e LABEL_VALUE="master-live-server" \
   -e REPORTS="vulnerabilityreports"
@@ -104,7 +105,7 @@ docker run -it -v /path/to/your/.kube/config:/root/.kube/config \
 | `defectDojoEvalTestTitle`             | `"false"`                  | Specifies whether the test title should be evaluated as a python function.                   |
 | `defectDojoMinimumSeverity`           | `Info`                     | The minimum severity level for findings in DefectDojo.                                       |
 | `defectDojoProductName`               | `product`                  | The name of the product in DefectDojo.                                                       |
-| `defectDojoProductTypeName`           | `Research and Development` | The type of the product in DefectDojo.                                                       |
+| `defectDojoProductTypeName`           | `` | The type of the product in DefectDojo.                                                       |
 | `defectDojoEnvName`                   | `Development`              | The type of the env in DefectDojo.                                                           |
 | `defectDojoPushToJira`                | `"false"`                  | Specifies whether findings should be pushed to Jira in DefectDojo.                           |
 | `defectDojoTestTitle`                 | `Kubernetes`               | The title of the test in DefectDojo.                                                         |

--- a/src/settings.py
+++ b/src/settings.py
@@ -36,7 +36,7 @@ DEFECT_DOJO_DEDUPLICATION_ON_ENGAGEMENT: bool = get_env_var_bool(
 )
 
 DEFECT_DOJO_PRODUCT_TYPE_NAME: str = os.getenv(
-    "DEFECT_DOJO_PRODUCT_TYPE_NAME", "Research and Development"
+    "DEFECT_DOJO_PRODUCT_TYPE_NAME", ""
 )
 DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME: bool = get_env_var_bool(
     "DEFECT_DOJO_EVAL_PRODUCT_TYPE_NAME"
@@ -58,7 +58,7 @@ DEFECT_DOJO_EVAL_ENGAGEMENT_NAME: bool = get_env_var_bool(
 )
 
 DEFECT_DOJO_PRODUCT_NAME: str = os.getenv(
-    "DEFECT_DOJO_PRODUCT_NAME", "Research and Development"
+    "DEFECT_DOJO_PRODUCT_NAME", "product"
 )
 DEFECT_DOJO_EVAL_PRODUCT_NAME: bool = get_env_var_bool("DEFECT_DOJO_EVAL_PRODUCT_NAME")
 


### PR DESCRIPTION
# Change default DEFECT_DOJO_PRODUCT_TYPE_NAME to allow empty values

## Description
This MR modifies the default value of DEFECT_DOJO_PRODUCT_TYPE_NAME to allow empty strings as valid values. The change is motivated by the DefectDojo API's `reimport-scan` endpoint behavior, which only requires `product_name` and `engagement_name` for scan reimports, making the `product_type_name` parameter optional. This aligns our implementation with the API's capabilities and simplifies the configuration when using reimport functionality.

## Technical Context
1. The DefectDojo API endpoint `reimport-scan` can operate with just:
  - product_name
  - engagement_name

2. Current Implementation Issue:
  - With the mandatory product_type_name configuration, if a product already exists in DefectDojo with the same name but under a different product_type, the API call fails due to a conflict
  - This forces users to ensure product_type alignment even when it's not necessary for the reimport operation
  - Making product_type_name optional avoids these conflicts and allows better integration with existing DefectDojo products

## Changes
- Update README.md to document empty string as a valid option for DEFECT_DOJO_PRODUCT_TYPE_NAME
- Modify src/settings.py to set default DEFECT_DOJO_PRODUCT_TYPE_NAME to empty string

## Documentation
Updated README.md to reflect the new default value and usage options, including explanation of API endpoint behavior and conflict resolution.

