### PR TITLE
Remote Cluster Configuration for Trivy-Dojo-Report-Operator

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -91,6 +91,10 @@ spec:
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.reports }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        {{- if .Values.remoteClusterKubeconfig }}
+        - name: KUBECONFIG
+          value: "/app/.kube/config"
+        {{- end }}
         image: {{ .Values.operator.trivyDojoReportOperator.image.repository }}:{{ .Values.operator.trivyDojoReportOperator.image.tag | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:
@@ -104,5 +108,21 @@ spec:
         {{- end }}
         securityContext: {{- toYaml .Values.operator.trivyDojoReportOperator.containerSecurityContext
           | nindent 10 }}
+        {{- if .Values.remoteClusterKubeconfig }}
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /app/.kube
+        {{- end }}
+      {{- if .Values.remoteClusterKubeconfig }}
+      volumes:
+      - name: kubeconfig
+        secret:
+          secretName: {{ include "charts.fullname" . }}-defect-dojo-api-credentials
+          items:
+          - key: kubeconfig
+            path: config
+      {{- end }}
       securityContext: {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      {{- if .Values.createRBAC }}
       serviceAccountName: {{ include "charts.fullname" . }}-account
+      {{- end }}

--- a/charts/templates/rbac.yaml
+++ b/charts/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.createRBAC }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -62,3 +63,4 @@ subjects:
 - kind: ServiceAccount
   name: '{{ include "charts.fullname" . }}-account'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/charts/templates/secret.yaml
+++ b/charts/templates/secret.yaml
@@ -4,9 +4,12 @@ metadata:
   name: {{ include "charts.fullname" . }}-defect-dojo-api-credentials
   labels:
   {{- include "charts.labels" . | nindent 4 }}
-stringData:
+data:
   apiKey: {{ required "defectDojoApiCredentials.apiKey is required" .Values.defectDojoApiCredentials.apiKey
-    | quote }}
+    | b64enc | quote }}
   url: {{ required "defectDojoApiCredentials.url is required" .Values.defectDojoApiCredentials.url
-    | quote }}
+    | b64enc | quote }}
+  {{- if .Values.remoteClusterKubeconfig }}
+  kubeconfig: {{ .Values.remoteClusterKubeconfig | quote }}
+  {{- end }}
 type: Opaque

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,6 +1,8 @@
 defectDojoApiCredentials:
   apiKey: "YOUR_DEFECTDOJO_API_KEY"
   url: "YOUR_DEFECTDOJO_URL"
+# -- Kubeconfig remote cluster already in base64
+remoteClusterKubeconfig: ""
 kubernetesClusterDomain: cluster.local
 account:
   serviceAccount:
@@ -54,3 +56,4 @@ operator:
     runAsNonRoot: true
     fsGroupChangePolicy: Always
     fsGroup: 1000
+createRBAC: true

--- a/deploy/trivy-dojo-report-operator.yaml
+++ b/deploy/trivy-dojo-report-operator.yaml
@@ -27,6 +27,7 @@ metadata:
 stringData:
   apiKey: "YOUR_DEFECTDOJO_API_KEY"
   url: "YOUR_DEFECTDOJO_URL"
+  kubeconfig: ""
 type: Opaque
 ---
 # Source: trivy-dojo-report-operator/templates/rbac.yaml
@@ -217,6 +218,16 @@ spec:
           runAsUser: 1000
           seccompProfile:
             type: RuntimeDefault
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /app/.kube
+      volumes:
+      - name: kubeconfig
+        secret:
+          secretName: telekom-mms-trivy-dojo-report-operator-defect-dojo-api-credentials
+          items:
+          - key: kubeconfig
+            path: config
       securityContext:
         fsGroup: 1000
         fsGroupChangePolicy: Always

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -32,6 +32,12 @@ def check_allowed_reports(report: str):
         )
         exit(1)
 
+@kopf.on.login()
+def login_fn(**kwargs):
+    if settings.KUBECONFIG:
+        return kopf.login_with_kubeconfig(**kwargs)
+    else:
+        return kopf.login_via_client(**kwargs)
 
 @kopf.on.startup()
 def configure(settings: kopf.OperatorSettings, **_):

--- a/src/settings.py
+++ b/src/settings.py
@@ -67,3 +67,4 @@ DEFECT_DOJO_DO_NOT_REACTIVATE: bool = get_env_var_bool("DEFECT_DOJO_DO_NOT_REACT
 LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
 
 REPORTS: list = os.getenv("REPORTS", "vulnerabilityreports").split(",")
+KUBECONFIG: str = os.getenv("KUBECONFIG", "")


### PR DESCRIPTION
## Description

This MR introduces the following changes to the `trivy-dojo-report-operator` application:

1. Added support for remote cluster configuration using a Kubernetes configuration (kubeconfig) file.
2. Implemented conditional RBAC creation based on the presence of a flag.
3. Updated the login function in the `handlers.py` file to handle the kubeconfig scenario.

## Changes

1. `charts/templates/deployment.yaml`:
   - Added a new environment variable `KUBECONFIG` with the value of the path of the mounted kubeconfig file.
   - Added a new volume mount and volume to handle the kubeconfig file, if provided.
   - Added a conditional check for the `createRBAC` flag to set the service account name.

2. `charts/templates/rbac.yaml`:
   - Added a conditional check for the `createRBAC` flag to create the service account, cluster role, and cluster role binding.

3. `charts/templates/secret.yaml`:
   - Added a new key-value pair to store the remote cluster kubeconfig, if provided.

4. `charts/values.yaml`:
   - Added a new field `remoteClusterKubeconfig` to store the base64-encoded remote cluster kubeconfig.
   - Added a new field `createRBAC` to control the creation of RBAC resources.

5. `deploy/trivy-dojo-report-operator.yaml`:
   - Added a new volume mount and volume to handle the kubeconfig file, if provided.

6. `src/handlers.py`:
   - Updated the `login_fn` function to handle the kubeconfig scenario.

7. `src/settings.py`:
   - Added a new environment variable `KUBECONFIG` to store the path to the kubeconfig file.

## Rationale

The primary goal of these changes is to provide the flexibility to fetch vulnerabilities from a remote Kubernetes cluster, in addition to the default behavior of fetching them from the same cluster where the operator is running.

If the `remoteClusterKubeconfig` value is provided, the operator will use the kubeconfig file to authenticate and interact with the remote cluster. In this case, there is no need to create RBAC resources, as the remote cluster's RBAC configuration will be used.

If the `remoteClusterKubeconfig` value is not provided, the operator will continue to use the default behavior of fetching vulnerabilities from the same cluster where it is running, and the RBAC resources will be created as before.

The changes to the `handlers.py` file ensure that the login process handles both the kubeconfig scenario and the default scenario, maintaining backward compatibility.
