### PR TITLE
Add affinity, nodeselector and tolerations to deployment

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -106,3 +106,15 @@ spec:
           | nindent 10 }}
       securityContext: {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "charts.fullname" . }}-account
+      {{- with .Values.operator.trivyDojoReportOperator.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.trivyDojoReportOperator.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.operator.trivyDojoReportOperator.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -25,6 +25,9 @@ operator:
       seccompProfile:
         type: RuntimeDefault
     resources: {}
+    affinity: {}
+    nodeSelector: {}
+    tolerations: []
     env:
       defectDojoActive: "true"
       defectDojoAutoCreateContext: "true"


### PR DESCRIPTION
**Identified problem**: as we want to better deploy the pods in the correct node and further set the correct values, I would need to be able to set the correct value for:
- Affinity
- Nodeselector
- Toleration

With my changes, I want to allow to set those values from the chart.