### PR TITLE
deactivate deleted report from the cluster

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         - name: DEFECT_DOJO_ACTIVE
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoActive
             }}
+        - name: DEFECT_DOJO_MITIGATE_FINDINGS
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoMitigateFindings
+            }}
         - name: DEFECT_DOJO_VERIFIED
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.defectDojoVerified
             }}

--- a/deploy/trivy-dojo-report-operator.yaml
+++ b/deploy/trivy-dojo-report-operator.yaml
@@ -158,6 +158,8 @@ spec:
               optional: false
         - name: DEFECT_DOJO_ACTIVE
           value: "true"
+        - name: DEFECT_DOJO_MITIGATE_FINDINGS
+          value: "false"
         - name: DEFECT_DOJO_VERIFIED
           value: "false"
         - name: DEFECT_DOJO_CLOSE_OLD_FINDINGS

--- a/src/settings.py
+++ b/src/settings.py
@@ -17,7 +17,7 @@ else:
 
 DEFECT_DOJO_API_KEY: str = get_required_env_var("DEFECT_DOJO_API_KEY")
 DEFECT_DOJO_URL: str = get_required_env_var("DEFECT_DOJO_URL")
-
+DEFECT_DOJO_MITIGATE_FINDINGS: str = get_required_env_var("DEFECT_DOJO_MITIGATE_FINDINGS")
 DEFECT_DOJO_ACTIVE: bool = get_env_var_bool("DEFECT_DOJO_ACTIVE")
 DEFECT_DOJO_VERIFIED: bool = get_env_var_bool("DEFECT_DOJO_VERIFIED")
 DEFECT_DOJO_CLOSE_OLD_FINDINGS: bool = get_env_var_bool(


### PR DESCRIPTION
**Idea:** I wanted to create a way to allow the user to Mitigate the finding when the report is not present anymore in the cluster

**What this MR does:**

- You have to set up a value in the chart that would allow the kopf on delete to be "activated"
- If the value is set to true it will start to listen to possible deleted report
- If it is the case, it will just change the status of the already existing finding