### PR TITLE
feat(multiplatform-images): Build images for arm64 platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
         name: Build and push to ghcr.io
         uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ghcr.io/telekom-mms/docker-trivy-dojo-operator:latest,ghcr.io/telekom-mms/docker-trivy-dojo-operator:${{ github.event.release.tag_name }}


### PR DESCRIPTION
### Multiplatform Images

Currently, the project is only building images for the  amd64 platform.

This is preventing us from running the operator in a k8s cluster with only arm64 nodes.

Thank you!