### PR TITLE
feat(extravolumes): Add possibility to define extra volumes to the de…

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -110,7 +110,16 @@ spec:
         {{- end }}
         securityContext: {{- toYaml .Values.operator.trivyDojoReportOperator.containerSecurityContext
           | nindent 10 }}
+        {{- with .Values.operator.trivyDojoReportOperator.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}  
       securityContext: {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
+      # Additional volumes on the output Deployment definition.
+      {{- with .Values.operator.trivyDojoReportOperator.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "charts.fullname" . }}-account
       {{- with .Values.operator.trivyDojoReportOperator.nodeSelector }}
       nodeSelector:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -28,6 +28,8 @@ operator:
     affinity: {}
     nodeSelector: {}
     tolerations: []
+    extraVolumeMounts: []
+    extraVolumes: [] 
     env:
       defectDojoActive: "true"
       defectDojoAutoCreateContext: "true"


### PR DESCRIPTION
### Configure volumes in deployment

Sometimes it's needed to configure extraVolumes in deployments.

In our case, we need to configure Secrets Store CSI Driver volumes to provide defectdojo credentials for deployment from Vault securely.

More information: https://secrets-store-csi-driver.sigs.k8s.io/getting-started/usage 

Currently, we are using a modified local version of the chart but it would be great if this feature can be included in the mainstream.

Thank you!