### PR TITLE
FEATURE: Allow Pull an Image from a Private Registry

### DIFF
--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -113,7 +113,11 @@ spec:
         {{- with .Values.operator.trivyDojoReportOperator.extraVolumeMounts }}
         volumeMounts:
           {{- toYaml . | nindent 10 }}
-        {{- end }}  
+        {{- end }}
+      {{- with .Values.operator.trivyDojoReportOperator.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext: {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
       # Additional volumes on the output Deployment definition.
       {{- with .Values.operator.trivyDojoReportOperator.extraVolumes }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -55,6 +55,7 @@ operator:
     image:
       repository: ghcr.io/telekom-mms/docker-trivy-dojo-operator
       tag: 0.8.6
+    imagePullSecrets: []
   type: ClusterIP
   podSecurityContext:
     runAsNonRoot: true


### PR DESCRIPTION
Currently, the Helm chart does not support pulling images from a private container registry when deploying the trivy-dojo-operator. This can be problematic in environments where access to public images is restricted, or custom/private images are required.

This feature request proposes adding support for imagePullSecrets, allowing users to specify Kubernetes secrets that enable the pulling of images from private registries.