### PR TITLE
feat: provide option to set http_proxy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ docker run -it -v /path/to/your/.kube/config:/root/.kube/config \
 | `defectDojoVerified`                  | `"false"`                  | Specifies whether findings should be marked as verified in DefectDojo.                       |
 | `defectDojoDoNotReactivate`           | `"true"`                   | If true the importing/reimporting will ignore uploaded active findings and not reactivate previously closed findings, while still creating new findings if there are new ones             |
 | `reports`                             | `"vulnerabilityreports"`   | Comma-separated list of reports that should be sent to DefectDojo. Possibilities: vulnerabilityreports, rbacassessmentreports, infraassessmentreports, configauditreports, exposedsecretreports |
+| `http_proxy`                          | `""`   | Option to set http_proxy variables to send requests through a proxy                                              |
+| `https_proxy`                         | `""`   | Option to set https_proxy variables to send requests through a proxy                                             |
 
 ### A note on eval
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ docker run -it -v /path/to/your/.kube/config:/root/.kube/config \
 | `defectDojoVerified`                  | `"false"`                  | Specifies whether findings should be marked as verified in DefectDojo.                       |
 | `defectDojoDoNotReactivate`           | `"true"`                   | If true the importing/reimporting will ignore uploaded active findings and not reactivate previously closed findings, while still creating new findings if there are new ones             |
 | `reports`                             | `"vulnerabilityreports"`   | Comma-separated list of reports that should be sent to DefectDojo. Possibilities: vulnerabilityreports, rbacassessmentreports, infraassessmentreports, configauditreports, exposedsecretreports |
-| `http_proxy`                          | `""`   | Option to set http_proxy variables to send requests through a proxy                                              |
-| `https_proxy`                         | `""`   | Option to set https_proxy variables to send requests through a proxy                                             |
+| `http_proxy`                          | `""`   | Option to set http_proxy variable                                             |
+| `https_proxy`                         | `""`   | Option to set https_proxy variable                                             |
 
 ### A note on eval
 

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
           value: {{ quote .Values.operator.trivyDojoReportOperator.env.reports }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        - name: HTTP_PROXY
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.http_proxy }}
+        - name: HTTPS_PROXY
+          value: {{ quote .Values.operator.trivyDojoReportOperator.env.https_proxy }}
         image: {{ .Values.operator.trivyDojoReportOperator.image.repository }}:{{ .Values.operator.trivyDojoReportOperator.image.tag | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -52,6 +52,8 @@ operator:
       defectDojoTestTitle: Kubernetes
       defectDojoVerified: "false"
       reports: vulnerabilityreports
+      http_proxy: ""
+      https_proxy: ""
     image:
       repository: ghcr.io/telekom-mms/docker-trivy-dojo-operator
       tag: 0.8.6

--- a/src/handlers.py
+++ b/src/handlers.py
@@ -16,6 +16,11 @@ PROMETHEUS_DISABLE_CREATED_SERIES = True
 
 c = prometheus.Counter("requests_total", "HTTP Requests", ["status"])
 
+if settings.HTTP_PROXY or settings.HTTPS_PROXY:
+    proxies = {
+        "http": settings.HTTP_PROXY,
+        "https": settings.HTTPS_PROXY,
+    }
 
 def check_allowed_reports(report: str):
     allowed_reports: list[str] = [
@@ -162,6 +167,7 @@ for report in settings.REPORTS:
                 data=data,
                 files=report_file,
                 verify=True,
+                proxies=proxies,
             )
             response.raise_for_status()
         except HTTPError as http_err:

--- a/src/settings.py
+++ b/src/settings.py
@@ -75,5 +75,5 @@ LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
 
 REPORTS: list = os.getenv("REPORTS", "vulnerabilityreports").split(",")
 
-HTTP_PROXY: str = get_env_var_bool("HTTP_PROXY") or get_env_var_bool("http_proxy")
-HTTPS_PROXY: str = get_env_var_bool("HTTPS_PROXY") or get_env_var_bool("https_proxy")
+HTTP_PROXY: str = os.getenv("HTTP_PROXY") or os.getenv("http_proxy")
+HTTPS_PROXY: str = os.getenv("HTTPS_PROXY") or os.getenv("https_proxy")

--- a/src/settings.py
+++ b/src/settings.py
@@ -74,3 +74,6 @@ DEFECT_DOJO_DO_NOT_REACTIVATE: bool = get_env_var_bool("DEFECT_DOJO_DO_NOT_REACT
 LOG_LEVEL: str = os.getenv("LOG_LEVEL", "INFO").upper()
 
 REPORTS: list = os.getenv("REPORTS", "vulnerabilityreports").split(",")
+
+HTTP_PROXY: str = get_env_var_bool("HTTP_PROXY") or get_env_var_bool("http_proxy")
+HTTPS_PROXY: str = get_env_var_bool("HTTPS_PROXY") or get_env_var_bool("https_proxy")


### PR DESCRIPTION
Provides option to set http_proxy variables.

We use this tool within on-premises and need to go through a proxy to reach our central defectdojo in the cloud. Hence we need proxy capabilities

Note this PR has not yet been tested by us. We will do this in the near future