### PR TITLE
Fix: Error when `proxies` is not defined.

### DIFF
--- a/src/handlers.py
+++ b/src/handlers.py
@@ -16,11 +16,10 @@ PROMETHEUS_DISABLE_CREATED_SERIES = True
 
 c = prometheus.Counter("requests_total", "HTTP Requests", ["status"])
 
-if settings.HTTP_PROXY or settings.HTTPS_PROXY:
-    proxies = {
-        "http": settings.HTTP_PROXY,
-        "https": settings.HTTPS_PROXY,
-    }
+proxies = {
+    "http": settings.HTTP_PROXY,
+    "https": settings.HTTPS_PROXY,
+} if settings.HTTP_PROXY or settings.HTTPS_PROXY else None
 
 def check_allowed_reports(report: str):
     allowed_reports: list[str] = [


### PR DESCRIPTION
### Description:
This PR fix and error than occurs when `proxies` is not defined, as shown in the logs:
```bash
Handler 'send_to_dojo' failed temporarily: Other error occurred: name 'proxies' is not defined. Retrying in 60 seconds
``` 
### Changes:

1. `src/handlers.py`
    - added logic to avoid undefined proxies var.

PS: related to this PR #112 